### PR TITLE
use --installed option while executing brew --prefix

### DIFF
--- a/lib/Crypt/OpenSSL/Guess.pm
+++ b/lib/Crypt/OpenSSL/Guess.pm
@@ -111,7 +111,7 @@ sub find_openssl_prefix {
     }
 
     # Homebrew (macOS) or LinuxBrew
-    if ($^O ne 'MSWin32' and my $prefix = `brew --prefix openssl 2>@{[File::Spec->devnull]}`) {
+    if ($^O ne 'MSWin32' and my $prefix = `brew --prefix --installed openssl 2>@{[File::Spec->devnull]}`) {
         chomp $prefix;
         return $prefix;
     }


### PR DESCRIPTION
It seems like `brew --prefix openssl` prints a directory even if openssl formula is not installed.

```
❯ brew --prefix --help
Usage: brew --prefix [--unbrewed] [--installed] [formula ...]
...
If formula is provided, display the location where formula is or would be
installed.
...
      --installed                  Outputs nothing and returns a failing
                                   status code if formula is not installed.
```

This PR adds --installed option to brew --prefix command so that brew --prefix prints a directory only if openssl formula is actually installed.