### PR TITLE
Fix synopsis

### DIFF
--- a/lib/Crypt/OpenSSL/Guess.pm
+++ b/lib/Crypt/OpenSSL/Guess.pm
@@ -226,7 +226,7 @@ Crypt::OpenSSL::Guess - Guess OpenSSL include path
 
     WriteMakefile(
         # ...
-        LIBS => ['-lssl -lcrypto ' . openssl_lib_paths()],
+        LIBS => [openssl_lib_paths() . ' -lssl -lcrypto'],
         INC  => openssl_inc_paths(), # guess include path or get from $ENV{OPENSSL_PREFIX}
     );
 

--- a/lib/Crypt/OpenSSL/Guess.pm
+++ b/lib/Crypt/OpenSSL/Guess.pm
@@ -221,7 +221,7 @@ Crypt::OpenSSL::Guess - Guess OpenSSL include path
 
 =head1 SYNOPSIS
 
-    use ExtUtils::MakerMaker;
+    use ExtUtils::MakeMaker;
     use Crypt::OpenSSL::Guess;
 
     WriteMakefile(


### PR DESCRIPTION
This PR fixes SYNOPSIS.

On my macOS, the following Makefile.PL:
```perl
use ExtUtils::MakeMaker;
use Crypt::OpenSSL::Guess;

WriteMakefile(
    # ...
    LIBS => ['-lssl -lcrypto ' . openssl_lib_paths()],
    INC  => openssl_inc_paths(), # guess include path or get from $ENV{OPENSSL_PREFIX}
);
```

gives

```
❯ perl Makefile.PL
Warning: Guessing NAME [test] from current directory name.
WARNING: /Users/skaji/env/plenv/versions/5.34.0/bin/perl is loading libcrypto in an unsafe way
zsh: abort      perl Makefile.PL
```

So I think `-L` must precede `-l`.